### PR TITLE
chage: Fix regression in print_date

### DIFF
--- a/src/chage.c
+++ b/src/chage.c
@@ -228,7 +228,7 @@ static void print_date (time_t date)
 	if (NULL == tp) {
 		(void) printf ("time_t: %lu\n", (unsigned long)date);
 	} else {
-		(void) strftime (buf, sizeof buf, iflg ? "%%Y-%%m-%%d" : "%%b %%d, %%Y", tp);
+		(void) strftime (buf, sizeof buf, iflg ? "%Y-%m-%d" : "%b %d, %Y", tp);
 		(void) puts (buf);
 	}
 }


### PR DESCRIPTION
Introduced by c6c8130db4319613a91dd07bbb845f6c33c5f79f .
After removing snprintf, the format string should get unescaped once.

Fixes #564

Reporter and patch author: DerMouse (github.com/DerMouse)